### PR TITLE
Fix CDN Replace, Page Title, and Arweave CDN Config Refactor

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,6 +5,7 @@ import 'react-toastify/dist/ReactToastify.css'
 import '@/styles/globals.css'
 import { useRouter } from 'next/router'
 import { ToastContainer } from 'react-toastify'
+import Head from 'next/head'
 import styled from 'styled-components'
 import Link from 'next/link'
 import { Layout, Space } from 'antd'
@@ -81,6 +82,9 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   return (
     <>
+      <Head>
+        <title>Holaplex | Design and Host Your Metaplex NFT Storefront</title>
+      </Head>
       <ToastContainer autoClose={15000} />
       <WalletProvider>
         {({ verifying, wallet }) => (

--- a/pages/storefronts.tsx
+++ b/pages/storefronts.tsx
@@ -74,12 +74,14 @@ const StoreImage = styled.img`
 
 const StoreFronts = () => {
   const { connect } = useContext(WalletContext)
+  const arweave = initArweave()
 
   const windowDimensions = useWindowDimensions();
   const [loading, setLoading] = useState(true)
   const [show, setShow] = useState(20)
   const [hasMoreStores, setHasMoreStores] = useState(true)
   const [storefronts, setStorefronts] = useState<Storefront[]>([])
+  const { api } = arweave.getConfig()
 
   const loadMoreStores = () => {
     const total = storefronts.length
@@ -99,7 +101,6 @@ const StoreFronts = () => {
   });
 
   useEffect(() => {
-    const arweave = initArweave()
     ArweaveSDK.using(arweave).storefront.list()
       .then(data => {
         const storefronts = data.map(st => st.storefront)
@@ -137,7 +138,7 @@ const StoreFronts = () => {
                     target="_blank"
                     rel="noreferrer"
                   >
-                    <Image preview={false} src={replace('https://arweave.net:443', ARWEAVE_CDN_HOST, item?.theme.logo.url || "")} alt="" width={75} height={75} />
+                    <Image preview={false} src={replace(`${api.protocol}://${api.host}:${api.port}`, ARWEAVE_CDN_HOST, item?.theme.logo.url || "")} alt="" width={75} height={75} />
                     <StoreName ellipsis>
                       {item?.meta.title}
                     </StoreName>

--- a/pages/storefronts.tsx
+++ b/pages/storefronts.tsx
@@ -137,7 +137,7 @@ const StoreFronts = () => {
                     target="_blank"
                     rel="noreferrer"
                   >
-                    <Image preview={false} src={replace('https://arweave.net:443', ARWEAVE_CDN_HOST, item?.theme.logo.url)} alt="" width={75} height={75} />
+                    <Image preview={false} src={replace('https://arweave.net:443', ARWEAVE_CDN_HOST, item?.theme.logo.url || "")} alt="" width={75} height={75} />
                     <StoreName ellipsis>
                       {item?.meta.title}
                     </StoreName>


### PR DESCRIPTION
### Changes
- There is a null logo url that is causing page not to render. https://aminae.holaplex.com/#/ Not sure how this happened since the fieled is required.
- Include page title for holaplex
- Adjust arweave CDN replace based on the active config