### PR TITLE
Pull uniq by pubkey for storefronts api

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -201,7 +201,7 @@ export default function Home() {
 
       <Community justify="center">
         <Col sm={20} md={20} lg={20} xl={18}>
-          <CenteredTitle level={2}>Join our community, 150 stores and counting!</CenteredTitle>
+          <CenteredTitle level={2}>Join our community, 200 stores and counting!</CenteredTitle>
           <List
             grid={{ xs: 1, sm: 2, md: 4, lg: 4, xl: 4, xxl: 4, gutter: 16 }}
             dataSource={higlightStores}

--- a/src/modules/arweave/client.ts
+++ b/src/modules/arweave/client.ts
@@ -175,7 +175,7 @@ const using = (arweave: Arweave): ArweaveScope => ({
         next = hasNextPage
       }
 
-      return uniqBy(view(lensPath(['storefront', 'subdomain'])), storefronts)
+      return uniqBy(view(lensPath(['storefront', 'pubkey'])), storefronts)
     },
     find: async (name: string, value: string): Promise<Storefront | null> => {
       const response = await query(
@@ -240,6 +240,8 @@ const using = (arweave: Arweave): ArweaveScope => ({
   }
 })
 
-export default {
+const client = {
   using,
 }
+
+export default client


### PR DESCRIPTION
### Issue
Plucking by subdomain was getting storefronts who have had their subdomain changed.

### Fix
Filter by pubkey which will account for any subdomain changes and give the true count of stores