### PR TITLE
Add cors to txt endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "next": "11.0.1",
     "next-images": "^1.8.1",
     "next-plugin-antd-less": "^1.3.0",
+    "nextjs-cors": "^1.0.6",
     "polished": "^4.1.3",
     "prisma": "2.25.0",
     "ramda": "^0.27.1",

--- a/pages/api/arweave/txt/[id].ts
+++ b/pages/api/arweave/txt/[id].ts
@@ -1,11 +1,17 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import { contains } from 'ramda'
 import { initArweave } from '@/modules/arweave'
+import NextCors from 'nextjs-cors'
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<string>
 ) {
+  await NextCors(req, res, {
+    methods: ['GET', 'HEAD'],
+    origin: '*',
+  })
+
   try {
     const arweave = initArweave()
     const id = req.query.id as string
@@ -27,8 +33,8 @@ export default async function handler(
     catch (_) {
     }
 
-    if (contains(res.getHeader("Content-Type"), ["text/html", "text/plain", , "text/xml", "application/json", "application/xml"])) {
-      dataParams.string = true
+    if (contains(res.getHeader("Content-Type"), ["text/html", "text/plain", "text/xml", "application/json", "application/xml"])) {
+      dataParams["string"] = true
     }
 
     const data = await arweave.transactions.getData(id, dataParams)
@@ -43,7 +49,7 @@ export default async function handler(
         res.setHeader('Allow', ['GET'])
         return res.status(405).end(`Method ${req.method} Not Allowed`)
     }
-  } catch (_) {  
+  } catch (_) {
     res.status(500).end()
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3337,6 +3337,13 @@ next@11.0.1:
     vm-browserify "1.1.2"
     watchpack "2.1.1"
 
+nextjs-cors@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/nextjs-cors/-/nextjs-cors-1.0.6.tgz#7537f81dbb23c3ca40968481c297d1934d91b28d"
+  integrity sha512-w00Xj01Xox8WWdUfUmOjzuNgEVf8ju4sM2R5O/eiEeKkSiUm7elx0aiI+aSXYzzBW5XdTLcnBf9L/VnHqQelcw==
+  dependencies:
+    cors "^2.8.5"
+
 node-fetch@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"


### PR DESCRIPTION
### Changes

In order to use Areweave CDN on Metaplex stores the endpoint must set CORs for all sites.

The CDN has also been updated to forward the origin header from the upstream.