### PR TITLE
fix: restored image duplicate handeling

### DIFF
--- a/pages/nfts/new.tsx
+++ b/pages/nfts/new.tsx
@@ -99,6 +99,18 @@ const initialState: State = {
   nftValues: [],
 };
 
+function getFinalFile(file: File, numberOfDuplicates: number) {
+  // if there is a duplicate of file, add it as file_1 etc.
+  return numberOfDuplicates > 0
+    ? (() => {
+        const fileNameParts = file.name.split('.');
+        const extension = fileNameParts.pop();
+        const finalName = fileNameParts.join('.') + '_' + numberOfDuplicates + '.' + extension;
+        return new File([file], finalName, { type: file.type });
+      })()
+    : file;
+}
+
 function reducer(state: State, action: MintAction) {
   switch (action.type) {
     case 'SET_IMAGES':
@@ -115,18 +127,7 @@ function reducer(state: State, action: MintAction) {
       return state.images.length < 10
         ? {
             ...state,
-            images: [
-              ...state.images,
-              nrOfDuplicates > 0
-                ? (() => {
-                    const fileNameParts = file.name.split('.');
-                    const extension = fileNameParts.pop();
-                    const finalName =
-                      fileNameParts.join('.') + '_' + nrOfDuplicates + '.' + extension;
-                    return new File([file], finalName, { type: file.type });
-                  })()
-                : file,
-            ],
+            images: [...state.images, getFinalFile(file, nrOfDuplicates)],
           }
         : state;
     case 'UPLOAD_FILES':

--- a/pages/nfts/new.tsx
+++ b/pages/nfts/new.tsx
@@ -99,16 +99,11 @@ const initialState: State = {
   nftValues: [],
 };
 
-function getFinalFile(file: File, numberOfDuplicates: number) {
-  // if there is a duplicate of file, add it as file_1 etc.
-  return numberOfDuplicates > 0
-    ? (() => {
-        const fileNameParts = file.name.split('.');
-        const extension = fileNameParts.pop();
-        const finalName = fileNameParts.join('.') + '_' + numberOfDuplicates + '.' + extension;
-        return new File([file], finalName, { type: file.type });
-      })()
-    : file;
+function getFinalFileWithUpdatedName(file: File, numberOfDuplicates: number) {
+  const fileNameParts = file.name.split('.');
+  const extension = fileNameParts.pop();
+  const finalName = fileNameParts.join('.') + '_' + numberOfDuplicates + '.' + extension;
+  return new File([file], finalName, { type: file.type });
 }
 
 function reducer(state: State, action: MintAction) {
@@ -122,12 +117,15 @@ function reducer(state: State, action: MintAction) {
       };
     case 'ADD_IMAGE':
       const file = action.payload as File;
-      const nrOfDuplicates = state.images.filter((i) => i.name === file.name).length;
+      const numberOfDuplicates = state.images.filter((i) => i.name === file.name).length;
 
       return state.images.length < 10
         ? {
             ...state,
-            images: [...state.images, getFinalFile(file, nrOfDuplicates)],
+            images: [
+              ...state.images,
+              numberOfDuplicates > 0 ? getFinalFileWithUpdatedName(file, numberOfDuplicates) : file,
+            ],
           }
         : state;
     case 'UPLOAD_FILES':

--- a/pages/nfts/new.tsx
+++ b/pages/nfts/new.tsx
@@ -109,9 +109,26 @@ function reducer(state: State, action: MintAction) {
         images: state.images.filter((i) => i.name !== (action.payload as String)),
       };
     case 'ADD_IMAGE':
+      const file = action.payload as File;
+      const nrOfDuplicates = state.images.filter((i) => i.name === file.name).length;
+
       return state.images.length < 10
-        ? { ...state, images: [...state.images, action.payload as File] }
-        : state; // since the dispactch is async(?) it did not reliably limit number of files from the Upload component.
+        ? {
+            ...state,
+            images: [
+              ...state.images,
+              nrOfDuplicates > 0
+                ? (() => {
+                    const fileNameParts = file.name.split('.');
+                    const extension = fileNameParts.pop();
+                    const finalName =
+                      fileNameParts.join('.') + '_' + nrOfDuplicates + '.' + extension;
+                    return new File([file], finalName, { type: file.type });
+                  })()
+                : file,
+            ],
+          }
+        : state;
     case 'UPLOAD_FILES':
       return { ...state, uploadedFiles: action.payload as Array<UploadedFilePin> };
     case 'SET_FORM_VALUES':

--- a/src/modules/nfts/components/wizard/Upload.tsx
+++ b/src/modules/nfts/components/wizard/Upload.tsx
@@ -96,10 +96,8 @@ export default function UploadStep({ nextStep, dispatch, images }: Props) {
       }
     },
     beforeUpload: (file, list) => {
-      const isUniqueFile = images.every((i) => i.name !== file.name);
-      if (isUniqueFile) {
-        dispatch({ type: 'ADD_IMAGE', payload: file });
-      }
+      dispatch({ type: 'ADD_IMAGE', payload: file });
+
       return false;
     },
   };

--- a/src/modules/nfts/components/wizard/Verify.tsx
+++ b/src/modules/nfts/components/wizard/Verify.tsx
@@ -56,10 +56,7 @@ export default function Verify({ previousStep, nextStep, dispatch, goToStep, ima
             <Upload
               accept={NFT_MIME_TYPE_UPLOAD_VALIDATION_STRING}
               showUploadList={false}
-              beforeUpload={(f) =>
-                images.every((i) => i.name !== f.name) && // is unique name
-                dispatch({ type: 'ADD_IMAGE', payload: f })
-              }
+              beforeUpload={(f) => dispatch({ type: 'ADD_IMAGE', payload: f })}
             >
               <AddNFTButton>
                 <Image width={24} height={24} src={XCloseIcon} alt="x-close" />


### PR DESCRIPTION
If a user tries to upload a file with the same name(and file extension) as a previously uploaded file (upload meaning putting it into the browser with a file input tag, not IPFS) the system should allow it, but tack on a _1 (2,3..) at the end of the file name. The alternative being to just skip the "new" file.
Sooo: User tries to upload "image.png" two times, the system gets "image.png" and "image_1.png", and the minting process continues.